### PR TITLE
Fall back on `monospace` font-family

### DIFF
--- a/src/ClojureFinland/css/styles.clj
+++ b/src/ClojureFinland/css/styles.clj
@@ -5,7 +5,7 @@
   (garden/css
    [:body
     {:color            "#55AD1B"
-     :font-family      "Courier"
+     :font-family      ["Courier" "monospace"]
      :background-color "#0F0D01"
      :font-size        "14px"}]
 


### PR DESCRIPTION
For the benefit of those systems that don't have Courier installed on them.