### PR TITLE
improve legibility

### DIFF
--- a/src/ClojureFinland/css/styles.clj
+++ b/src/ClojureFinland/css/styles.clj
@@ -10,7 +10,8 @@
      :font-size        "14px"}]
 
    [:a
-    {:color "#20A5BE"}]
+    {:color "#20A5BE"
+     :text-underline-position "under"}]
 
    [:a:hover
     {:color "#24B6D2"}]
@@ -22,7 +23,8 @@
     {:vertical-align "top"}]
 
    [:.code
-    {:color "#8D9798"}]
+    {:color "#8D9798"
+     :font-weight "bold"}]
 
    [:.separator
     {:height "0.5em"}]

--- a/src/ClojureFinland/css/styles.clj
+++ b/src/ClojureFinland/css/styles.clj
@@ -4,25 +4,25 @@
 (defn gen-styles [_]
   (garden/css
    [:body
-    {:color            "#55AD1B"
+    {:color            "#5DBE1E"
      :font-family      ["Courier" "monospace"]
-     :background-color "#0F0D01"
+     :background-color "#000000"
      :font-size        "14px"}]
 
    [:a
-    {:color "#1D96AD"}]
+    {:color "#20A5BE"}]
 
    [:a:hover
-    {:color "#21a5bf"}]
+    {:color "#24B6D2"}]
 
    [:h1 :h2
-    {:color "#99A3A4"}]
+    {:color "#A8B3B4"}]
 
    [:table :td
     {:vertical-align "top"}]
 
    [:.code
-    {:color "#80898a"}]
+    {:color "#8D9798"}]
 
    [:.separator
     {:height "0.5em"}]


### PR DESCRIPTION
- increase color contrast by setting black background and adding 10% to color Values (HSV)
- set link underline so that it does not cross descenders
- use bold font for `.code` blocks

Before
![Before](https://user-images.githubusercontent.com/21062331/84860180-48f78800-b077-11ea-9c44-c97019096904.png)

After
![After](https://user-images.githubusercontent.com/21062331/84860204-5280f000-b077-11ea-84a6-bb766096fafa.png)
