### PR TITLE
fix scaling on mobile devices

### DIFF
--- a/src/ClojureFinland/html/page.clj
+++ b/src/ClojureFinland/html/page.clj
@@ -167,6 +167,7 @@
       [:meta {:http-equiv "refresh" :content 1}])
 
     [:meta {:charset "utf-8"}]
+    [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
     (page/include-css "styles.css")]
 
    [:body


### PR DESCRIPTION
Issue: rendered "Clojure maps" do not scale on mobile devices
Solution: set meta tag for viewport
Reference: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html#//apple_ref/doc/uid/TP40006509-SW26