### PR TITLE
chore(accessibility): use html tables for Clojure maps

### DIFF
--- a/src/ClojureFinland/css/styles.clj
+++ b/src/ClojureFinland/css/styles.clj
@@ -19,15 +19,20 @@
    [:h1 :h2
     {:color "#A8B3B4"}]
 
-   [:table :td
+   [:table
+    {:text-align "left"}]
+
+   [:table :th :td
     {:vertical-align "top"}]
+
+   ["tbody::after"
+    {:content "''"
+     :display "block"
+     :height "0.5em"}]
 
    [:.code
     {:color "#8D9798"
      :font-weight "bold"}]
-
-   [:.separator
-    {:height "0.5em"}]
 
    [:.container
     {:display               "inline-grid"

--- a/src/ClojureFinland/css/styles.clj
+++ b/src/ClojureFinland/css/styles.clj
@@ -32,15 +32,4 @@
 
    [:.code
     {:color "#8D9798"
-     :font-weight "bold"}]
-
-   [:.container
-    {:display               "inline-grid"
-     :grid-template-columns "0.75em min-content 0.5em"}]
-
-   [:.item-first
-    {:padding-top "0.2em"}]
-
-   [:.item-last
-    {:padding-bottom "0.25em"
-     :align-self     "end"}]))
+     :font-weight "bold"}]))

--- a/src/ClojureFinland/html/page.clj
+++ b/src/ClojureFinland/html/page.clj
@@ -129,7 +129,7 @@
       (fn [i [k v]]
         [:tr
          (into [:td {:aria-hidden "true"}] (if (= 0 i) "{" "&nbsp;"))
-         [:th (keyword-output k)]
+         [:th {:scope "row"} (keyword-output k)]
          [:td (let [column (cond
                              (map? v)  (table-output v)
                              (link? v) (link v)


### PR DESCRIPTION
- put related Clojure maps in one table
- render Clojure maps with row header for map key
- use tbody elements for Clojure maps
- remove divider elements from layout
- set aria-hidden for map parens

*Note*: fixes dangling parenthesis. e.g., after `Meetup Groups -> :bridge`