### PR TITLE
style(font): use Cousine for better readability

### DIFF
--- a/src/ClojureFinland/css/styles.clj
+++ b/src/ClojureFinland/css/styles.clj
@@ -5,7 +5,7 @@
   (garden/css
    [:body
     {:color            "#5DBE1E"
-     :font-family      ["Courier" "monospace"]
+     :font-family      ["Cousine" "monospace"]
      :background-color "#000000"
      :font-size        "14px"}]
 

--- a/src/ClojureFinland/html/page.clj
+++ b/src/ClojureFinland/html/page.clj
@@ -173,6 +173,8 @@
     (when dev
       [:meta {:http-equiv "refresh" :content 1}])
 
+    [:link {:href "https://fonts.googleapis.com/css2?family=Cousine&display=swap" :rel "stylesheet"}]
+
     [:meta {:charset "utf-8"}]
     [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
     (page/include-css "styles.css")]


### PR DESCRIPTION
"[Cousine is a] sans serif design that is metrically compatible with Courier New™.
 Cousine offers improved on-screen readability characteristics ..."

See https://fonts.google.com/specimen/Cousine?selection.family=Cousine&sidebar.open#standard-styles

Note: Loading CSS and woff2 for Cousine from CDN is 20kB. 

Before
![Screenshot with Courier](https://user-images.githubusercontent.com/21062331/85010508-c9e27c80-b168-11ea-9791-b9dcd4bafb1e.png)

After
![Screenshot with Cousine](https://user-images.githubusercontent.com/21062331/85010566-e41c5a80-b168-11ea-8d2f-4578a165733f.png)
